### PR TITLE
Potential fix for code scanning alert no. 2: Regular expression injection

### DIFF
--- a/themes/hexo/LayoutSearch.js
+++ b/themes/hexo/LayoutSearch.js
@@ -11,6 +11,10 @@ import TagItemMini from './components/TagItemMini'
 import Card from './components/Card'
 import Link from 'next/link'
 
+const escapeRegExp = (value) => {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export const LayoutSearch = props => {
   const { keyword, tags, categories } = props
   const { locale } = useGlobal()
@@ -23,10 +27,11 @@ export const LayoutSearch = props => {
       // 自动聚焦到搜索框
       cRef?.current?.focus()
       if (currentSearch) {
+        const safeSearch = escapeRegExp(currentSearch)
         const targets = document.getElementsByClassName('replace')
         for (const container of targets) {
           if (container && container.innerHTML) {
-            const re = new RegExp(currentSearch, 'gim')
+            const re = new RegExp(safeSearch, 'gim')
             const instance = new Mark(container)
             instance.markRegExp(re, {
               element: 'span',


### PR DESCRIPTION
Potential fix for [https://github.com/Jeffreyhung/NotionBlog/security/code-scanning/2](https://github.com/Jeffreyhung/NotionBlog/security/code-scanning/2)

General fix: When constructing a regular expression from user input, first escape any regex metacharacters so the pattern is treated as a literal string, or otherwise validate/whitelist allowed characters. Here, we want search terms to be treated as literal text to highlight, so we should escape regex metacharacters in `currentSearch` before passing it to `RegExp` and `markRegExp`.

Best fix for this code: Define a small helper that escapes regex metacharacters in a string (equivalent to lodash’s `_.escapeRegExp`) and use it to derive a `safeSearch` string from `currentSearch`. Then construct the regex from `safeSearch` instead of `currentSearch`. This preserves the current behavior for normal text but prevents a user from injecting a custom regex pattern. The change is localized to `LayoutSearch.js`, around the `new RegExp` call, and requires no external dependencies.

Concretely:
- Inside the `useEffect` callback, before `new RegExp(currentSearch, 'gim')`, introduce a function `escapeRegExp` (or define it at the top level of the module) that escapes `.*+?^${}()|[\]\\` and similar metacharacters.
- Use `const safeSearch = escapeRegExp(String(currentSearch))` and then `const re = new RegExp(safeSearch, 'gim')`.
- Optionally guard against empty strings after trimming, though `if (currentSearch)` already filters most falsy cases.

No new imports are strictly necessary; we can implement `escapeRegExp` inline using a well-known one-liner.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
