### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/components/PrismMac.js
+++ b/components/PrismMac.js
@@ -43,11 +43,12 @@ const renderMermaid = async() => {
   const mermaidPres = document.querySelectorAll('pre.notion-code.language-mermaid')
   if (mermaidPres) {
     for (const e of mermaidPres) {
-      const chart = e.querySelector('code').textContent
+      const chart = e.querySelector('code')?.textContent
       if (chart && !e.querySelector('.mermaid')) {
         const m = document.createElement('div')
         m.className = 'mermaid'
-        m.innerHTML = chart
+        // Store the diagram source as data, avoid interpreting it as HTML
+        m.setAttribute('data-graph', chart)
         e.appendChild(m)
       }
     }
@@ -59,6 +60,16 @@ const renderMermaid = async() => {
     for (const e of mermaidsSvg) {
       if (e?.firstChild?.nodeName !== 'svg') {
         needLoad = true
+      }
+      // Populate each mermaid container from its data attribute safely,
+      // then let Mermaid process the content.
+      for (const e of mermaidsSvg) {
+        if (e?.firstChild?.nodeName !== 'svg') {
+          const graphSource = e.getAttribute('data-graph')
+          if (graphSource) {
+            e.textContent = graphSource
+          }
+        }
       }
     }
     if (needLoad) {


### PR DESCRIPTION
Potential fix for [https://github.com/Jeffreyhung/NotionBlog/security/code-scanning/1](https://github.com/Jeffreyhung/NotionBlog/security/code-scanning/1)

In general, the fix is to stop taking raw text from the DOM and injecting it into `innerHTML` without escaping. For Mermaid, you can instead pass the diagram source string directly to Mermaid’s API and/or store it in a non-HTML attribute, letting Mermaid render into a dedicated container element. This preserves current functionality (rendering Mermaid diagrams) without reinterpreting DOM text as HTML.

Best minimal change here: keep reading the diagram source from `<code>.textContent`, but no longer set `m.innerHTML = chart`. Instead:

1. Create a `<div class="mermaid">` container.
2. Store the diagram source in a `data-` attribute of that container (e.g., `data-graph`).
3. Append the container to the `<pre>` element.
4. When Mermaid is loaded, read the diagram source from each container’s `data-graph` and populate its `textContent` (or call `mermaid.render`), so the untrusted data is never directly assigned to `innerHTML`.

Given the constraint of only editing this file and not changing imports beyond well-known packages, we can implement a self-contained fix by:

- Modifying `renderMermaid`’s first loop (lines 45–52) to:
  - Create the `.mermaid` element.
  - Assign `chart` to a `data-graph` attribute instead of `innerHTML`.
- Modifying the second part (lines 56–67) to:
  - After dynamically importing `mermaid`, iterate over `.mermaid` elements.
  - For each element that does not yet contain an SVG, read `data-graph`, set `textContent` to that string (safe), and then call `asyncMermaid.default.contentLoaded()` once.

No additional third-party dependencies are strictly needed; we just stop using `innerHTML` for this untrusted data and wire Mermaid initialization around `data-graph` and `textContent`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
